### PR TITLE
Enable desktop link create in onedrive desktop

### DIFF
--- a/Windows/aux_bin/create_oasys_icon1.2.bat
+++ b/Windows/aux_bin/create_oasys_icon1.2.bat
@@ -1,6 +1,18 @@
 @echo off
 
-%cd%\aux_bin\create_link.bat -linkfile "C:%HOMEPATH%\Desktop\Oasys 1.2.lnk" -target "C:%HOMEPATH%\Miniconda3\Scripts\activate.bat" -linkarguments "& python -m oasys.canvas" -iconlocation "%cd%\aux_bin\oasys.ico"
+set filelink = "C:%HOMEPATH%\Desktop\Oasys 1.2.lnk"
+
+echo Checking users home for Desktop folder which can sometimes be missing if the
+echo desktop is redirected towards "c:\users\<username>Onedrive - <ORGNAME>\Desktop"
+if not exist "C:%HOMEPATH%\Desktop" (
+	echo Looking for Desktop folder in the Onedrive.
+	if exist "%OneDrive%\Desktop" (
+		set filelink="%OneDrive%\Desktop\Oasys 1.2.lnk"
+		)
+	)
+echo The link to be created is: %filelink%
+
+%cd%\aux_bin\create_link.bat -linkfile %filelink% -target "C:%HOMEPATH%\Miniconda3\Scripts\activate.bat" -linkarguments "& python -m oasys.canvas" -iconlocation "%cd%\aux_bin\oasys.ico"
 
 
 


### PR DESCRIPTION
Certain configuration of One-drive and Teams can remove the users desktop folder and remaps Desktop to the version stored on One-drive. This fix detects missing desktop and alters the linkfile to be created. 